### PR TITLE
Fix: Typo in Lives Heading

### DIFF
--- a/src/app/apps/lives/app/saints/[[...saint]]/page.tsx
+++ b/src/app/apps/lives/app/saints/[[...saint]]/page.tsx
@@ -19,7 +19,7 @@ export default async function SayingsApp() {
         <h1
           className={`font-synaxisHeader text-5xl font-extrabold tracking-tight text-primary-gold-600 sm:text-[5rem]`}
         >
-          <span className="text-secondary-red-600">Sayings</span> of the Fathers
+          <span className="text-secondary-red-600">Lives</span> of the Saints
         </h1>
 
         <h2>Saint Silouan the Athonite</h2>

--- a/src/app/apps/lives/app/submit-saint/page.tsx
+++ b/src/app/apps/lives/app/submit-saint/page.tsx
@@ -17,7 +17,7 @@ export default async function SayingsApp() {
         <h1
           className={`font-synaxisHeader text-5xl font-extrabold tracking-tight text-primary-gold-600 sm:text-[5rem]`}
         >
-          <span className="text-secondary-red-600">Sayings</span> of the Fathers
+          <span className="text-secondary-red-600">Lives</span> of the Saints
         </h1>
 
         <div className="w-3/5">


### PR DESCRIPTION
## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/theSynaxis/SynaxisApp/blob/main/CONTRIBUTING.md).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

This PR will fix the typo in the heading for pages in the Lives app: Single Saint page and Submit Saint page.